### PR TITLE
revert "fix: move dummy comp to active comp"

### DIFF
--- a/scripts/klayout/read_layout.py
+++ b/scripts/klayout/read_layout.py
@@ -22,18 +22,13 @@ def check_top(
     options = pya.LoadLayoutOptions()
     lm = pya.LayerMap()
 
-    # Dummy comp to active comp
-    lm.map(pya.LayerInfo(22, 4), 0, pya.LayerInfo(22, 0))
-
-    # Dummy poly2 to active poly2
-    lm.map(pya.LayerInfo(30, 4), 1, pya.LayerInfo(30, 0))
-
-    # Dummy metal to active metal
-    lm.map(pya.LayerInfo(34, 4), 2, pya.LayerInfo(34, 0))
-    lm.map(pya.LayerInfo(36, 4), 3, pya.LayerInfo(36, 0))
-    lm.map(pya.LayerInfo(42, 4), 4, pya.LayerInfo(42, 0))
-    lm.map(pya.LayerInfo(46, 4), 5, pya.LayerInfo(46, 0))
-    lm.map(pya.LayerInfo(81, 4), 6, pya.LayerInfo(81, 0))
+    # Dummy metal and poly to active metal and poly
+    lm.map(pya.LayerInfo(30, 4), 0, pya.LayerInfo(30, 0))
+    lm.map(pya.LayerInfo(34, 4), 1, pya.LayerInfo(34, 0))
+    lm.map(pya.LayerInfo(36, 4), 2, pya.LayerInfo(36, 0))
+    lm.map(pya.LayerInfo(42, 4), 3, pya.LayerInfo(42, 0))
+    lm.map(pya.LayerInfo(46, 4), 4, pya.LayerInfo(46, 0))
+    lm.map(pya.LayerInfo(81, 4), 5, pya.LayerInfo(81, 0))
 
     options.set_layer_map(lm, True)
 


### PR DESCRIPTION
wafer-space/gf180mcu-precheck#38 fixes DCF.5 but leads to DF.12.

One solution would be to generate some Nplus or Pplus under dummy comp. Needs more investigation.