### PR TITLE
fix: add procps so the KLayout DRC density deck can call pmap

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
               ];
             extra-packages = with pkgs; [
               gnumake # Required for using Makefile in nix environment
+              procps # Provides `pmap`, shelled out to by the open_pdks gf180mcu KLayout DRC density deck
             ];
           });
         }


### PR DESCRIPTION
## Problem

Every manufacturability check fails at **Density Check (stage 6/16)** with:

```
sh: line 1: pmap: command not found
ERROR: In .../gf180mcuD/libs.tech/klayout/tech/drc/gf180mcu.drc: undefined method `strip' for nil
ERROR: NoMethodError: undefined method `strip' for nil in Executable::execute
Density Check: subprocess (1, ['klayout', ... 'gf180mcu.drc' ...]) failed
```

The open_pdks GF180MCU KLayout DRC deck installs a logger formatter that shells
out to `pmap` on every log line to report memory usage:

```ruby
# gf180mcu.drc
logger.formatter = proc do |_severity, datetime, _progname, msg|
  "#{datetime}: Memory Usage (" + `pmap #{Process.pid} | tail -1`[10, 40].strip + ") : #{msg}\n"
end
```

This image is built `FROM nixos/nix:latest` and runs everything through
`dev-shell` (`nix develop --command`), so **only the nix store is on `PATH`** —
the host system's `procps` is not present. With `pmap` missing, the backtick
returns `""`, `""[10, 40]` evaluates to `nil`, and `nil.strip` raises
`NoMethodError`. Because it's in the logger formatter, the **first**
`logger.info(...)` aborts the deck immediately, so **100% of checks fail** at the
density stage.

(The `gf180mcu-project-template` never hits this because it isn't containerized
from a minimal base — it runs in `nix develop` on a host/CI where system
`procps` is already on `PATH`.)

## Fix

Add `procps` to the dev-shell's `extra-packages` so `pmap` is on `PATH`
regardless of the minimal base image:

```nix
extra-packages = with pkgs; [
  gnumake
  procps # Provides `pmap`, shelled out to by the open_pdks gf180mcu KLayout DRC density deck
];
```

## Verification

Built the image from this branch and ran the smoke test:

- `docker run --rm <img> which pmap` →
  `/nix/store/…-devshell-dir/bin/pmap` ✅ (pmap now on PATH)
- `docker run --rm <img> make precheck` → the **Density Check (stage 6/16) now
  runs to completion** instead of crashing. The deck emits its
  `Memory Usage (NNNNK) : …` log lines (the exact formatter that previously
  raised `nil.strip`), e.g. `Memory Usage (3621248K) : Executing rule M3.4`, and
  the flow proceeds through density → antenna → the remaining checks. No
  `pmap: command not found`, no `undefined method 'strip'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJg1j3hHixid3RvGbtWZun
