### PR TITLE
Verify built Docker image with a complete DRC check before publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,17 @@ jobs:
       packages: write
 
     steps:
+      # The precheck image bundles the full nix EDA toolchain + PDK and is
+      # loaded into the local daemon for verification, so free up disk first.
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@v5
+        with:
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-haskell: "true"
+          remove-codeql: "true"
+          remove-docker-images: "true"
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -84,13 +95,56 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.version.outputs.version }}
 
-      - name: Build and push Docker image
+      # Build the image and load it into the local Docker daemon (do NOT push
+      # yet) so the exact bytes can be DRC-verified before anything is
+      # published. provenance:false is required because `load: true` cannot
+      # import a buildx attestation manifest-list into the Docker daemon.
+      - name: Build Docker image (load for verification)
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
-          # Only push to GHCR for branch/tag pushes on the main repo (not PRs, not forks)
-          push: ${{ github.event_name != 'pull_request' && github.repository == 'wafer-space/gf180mcu-precheck' }}
+          load: true
+          push: false
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: ${{ steps.gha_cache_permissions.outputs.can_write == 'true' && 'type=gha,mode=max' || '' }}
+
+      # A known-good design to drive a complete DRC run. Cloned on the host;
+      # the container itself runs fully offline (network_disabled).
+      - name: Clone example layouts
+        run: git clone --depth 1 https://github.com/wafer-space/gf180mcu-example-layouts.git
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      # Verify the freshly built image can run a complete DRC check using the
+      # exact command line and container configuration that the
+      # platform.wafer.space checker machines use (tasks_checks.py:do_starting).
+      #
+      # The image is pinned by its immutable content-addressed ID, not a tag,
+      # so a concurrent build/publish cannot swap it out from under the test.
+      - name: Verify precheck DRC on the built image
+        run: |
+          uv run scripts/verify_precheck_docker.py \
+            --image "${{ steps.build.outputs.imageid }}" \
+            --input gf180mcu-example-layouts/5v/0p5x0p5/chip_top.oas \
+            --top chip_top \
+            --slot 0p5x0p5 \
+            --id DEADBEEF
+
+      # Publish only after verification passes. The cache is warm from the build
+      # above, so this re-exports the identical image near-instantly.
+      # Only push for branch/tag pushes on the main repo (not PRs, not forks).
+      - name: Push Docker image
+        id: push
+        if: github.event_name != 'pull_request' && github.repository == 'wafer-space/gf180mcu-precheck'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -133,7 +133,18 @@ jobs:
             --input gf180mcu-example-layouts/5v/0p5x0p5/chip_top.oas \
             --top chip_top \
             --slot 0p5x0p5 \
-            --id DEADBEEF
+            --id DEADBEEF \
+            --output verify-output/design.gds
+
+      # Upload the GDS produced by the verification DRC run. Runs even if a
+      # later step fails, and tolerates absence (a failed precheck writes none).
+      - name: Upload verified output GDS
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verified-design-gds
+          path: verify-output/design.gds
+          if-no-files-found: warn
 
       # Publish only after verification passes. We push the *exact* image that
       # was just verified (pinned by its immutable ID) rather than rebuilding,

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -135,16 +135,14 @@ jobs:
             --slot 0p5x0p5 \
             --id DEADBEEF
 
-      # Publish only after verification passes. The cache is warm from the build
-      # above, so this re-exports the identical image near-instantly.
-      # Only push for branch/tag pushes on the main repo (not PRs, not forks).
-      - name: Push Docker image
+      # Publish only after verification passes. We push the *exact* image that
+      # was just verified (pinned by its immutable ID) rather than rebuilding,
+      # so the registry receives byte-for-byte the image that passed the DRC
+      # check. Only push for branch/tag pushes on the main repo (not PRs/forks).
+      - name: Push verified Docker image
         id: push
         if: github.event_name != 'pull_request' && github.repository == 'wafer-space/gf180mcu-precheck'
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+        env:
+          IMAGE_ID: ${{ steps.build.outputs.imageid }}
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: uv run scripts/push_image_tags.py

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
           remove-docker-images: "true"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch all history for git-describe
 
@@ -70,11 +70,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -101,7 +101,7 @@ jobs:
       # import a buildx attestation manifest-list into the Docker daemon.
       - name: Build Docker image (load for verification)
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -118,7 +118,12 @@ jobs:
         run: git clone --depth 1 https://github.com/wafer-space/gf180mcu-example-layouts.git
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
+        with:
+          # The helper scripts declare deps inline (PEP 723), so there is no
+          # uv.lock / requirements.txt to key a cache on. Disable caching to
+          # avoid a "cache will never get invalidated" warning.
+          enable-cache: false
 
       # Verify the freshly built image can run a complete DRC check using the
       # exact command line and container configuration that the
@@ -140,7 +145,7 @@ jobs:
       # later step fails, and tolerates absence (a failed precheck writes none).
       - name: Upload verified output GDS
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: verified-design-gds
           path: verify-output/design.gds

--- a/scripts/push_image_tags.py
+++ b/scripts/push_image_tags.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 wafer.space
+# SPDX-License-Identifier: Apache-2.0
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+
+"""Push an already-built, already-verified local image to its registry tags.
+
+The publish workflow builds the image, loads it into the local Docker daemon,
+and DRC-verifies it by its immutable image ID. This script then publishes
+*that exact image*: it re-tags the verified image ID onto each registry tag
+(so a concurrent build cannot have moved a tag onto a different image in the
+local daemon) and pushes each tag. The registry therefore receives the
+byte-for-byte image that passed verification — no rebuild, no second exporter,
+no chance of publishing different bytes than were tested.
+
+Inputs are read from the environment (the GitHub-recommended way to pass
+``${{ }}`` values, avoiding shell-injection and multi-line quoting issues):
+
+* ``IMAGE_ID``   – the verified image ID (e.g. ``sha256:...``)
+* ``IMAGE_TAGS`` – newline-separated registry tags to publish
+"""
+
+import os
+import subprocess
+import sys
+
+
+def main() -> int:
+    image_id = os.environ.get("IMAGE_ID", "").strip()
+    tags = [t.strip() for t in os.environ.get("IMAGE_TAGS", "").splitlines() if t.strip()]
+
+    if not image_id:
+        print("[push] IMAGE_ID is empty — nothing to publish", file=sys.stderr)
+        return 1
+    if not tags:
+        print("[push] IMAGE_TAGS is empty — no tags to publish", file=sys.stderr)
+        return 1
+
+    print(f"[push] publishing verified image {image_id} to {len(tags)} tag(s)")
+    for tag in tags:
+        # Re-tag the verified image ID immediately before pushing so we publish
+        # exactly what was verified, even if the tag was touched concurrently.
+        print(f"[push] docker tag {image_id} {tag}", flush=True)
+        subprocess.run(["docker", "tag", image_id, tag], check=True)
+        print(f"[push] docker push {tag}", flush=True)
+        subprocess.run(["docker", "push", tag], check=True)
+
+    print(f"[push] published verified image {image_id} to all {len(tags)} tag(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_precheck_docker.py
+++ b/scripts/verify_precheck_docker.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2025 wafer.space
+# SPDX-License-Identifier: Apache-2.0
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["docker"]
+# ///
+
+"""Verify a built gf180mcu-precheck Docker image by running a complete DRC check.
+
+This script is a faithful, self-contained stand-in for the way the
+platform.wafer.space checker machines launch a manufacturability check
+(see ``wafer_space/projects/tasks_checks.py:do_starting``). It deliberately
+reproduces the *exact* mechanism the production checkers use rather than a
+convenient shortcut, so that a passing run here proves the published image can
+actually complete a DRC check the same way the platform invokes it:
+
+* the same ``precheck.py`` command line
+  (``--input /input/design.gds --output /output/design.gds --top ... --slot ... --id ...``),
+* the same container configuration
+  (``working_dir=/workspace``, ``network_disabled=True``, ``mem_limit``,
+  ``COLUMNS``/``TERM`` environment),
+* the same no-bind-mount file transfer: the input layout is uploaded via
+  ``put_archive`` to ``/input/design.gds`` and an empty ``/output`` directory is
+  created, then the output GDS is read back from ``/output/design.gds``.
+
+The image is referenced by its immutable content-addressed ID (e.g. the
+``imageid`` emitted by docker/build-push-action), never by a mutable tag, so the
+verification always runs the exact image that was built even when several
+images are being built/published concurrently on a shared Docker daemon.
+
+Exit status is ``0`` only if the container exits ``0`` *and* a non-empty
+``/output/design.gds`` was produced.
+"""
+
+import argparse
+import io
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+import docker
+import docker.errors
+
+
+# These two helpers are intentionally identical to
+# platform.wafer.space/wafer_space/projects/docker_utils.py so the bytes
+# uploaded to the container match production exactly.
+def create_tar_archive(file_path: Path, arcname: str) -> io.BytesIO:
+    """Create an in-memory tar archive containing ``file_path`` as ``arcname``."""
+    # A temp file keeps peak memory low for large GDS files, matching the
+    # platform helper, then we hand back an in-memory stream for put_archive.
+    with tempfile.NamedTemporaryFile(suffix=".tar") as temp_file:
+        with tarfile.open(fileobj=temp_file, mode="w") as tar:
+            tar.add(str(file_path), arcname=arcname)
+        temp_file.seek(0)
+        return io.BytesIO(temp_file.read())
+
+
+def create_directory_tar(dirname: str) -> io.BytesIO:
+    """Create an in-memory tar archive containing a single empty directory."""
+    tar_stream = io.BytesIO()
+    with tarfile.open(fileobj=tar_stream, mode="w") as tar:
+        dir_info = tarfile.TarInfo(name=dirname)
+        dir_info.type = tarfile.DIRTYPE
+        dir_info.mode = 0o755
+        tar.addfile(dir_info)
+    tar_stream.seek(0)
+    return tar_stream
+
+
+def run_check(
+    image: str,
+    input_layout: Path,
+    top: str,
+    slot: str,
+    die_id: str,
+    mem_limit: str,
+) -> int:
+    """Run the precheck in a container exactly as the platform does.
+
+    Returns the container exit code (and asserts the output GDS exists).
+    """
+    client = docker.from_env()
+
+    # The exact command the checker machines build in do_starting. The image
+    # ENTRYPOINT is ``dev-shell`` and WORKDIR is /workspace, so this runs inside
+    # the offline nix environment with precheck.py on the path.
+    command = [
+        "python3",
+        "precheck.py",
+        "--input",
+        "/input/design.gds",
+        "--output",
+        "/output/design.gds",
+        "--top",
+        top,
+        "--slot",
+        slot,
+        "--id",
+        die_id,
+    ]
+    print(f"[verify] image:   {image}")
+    print(f"[verify] command: {' '.join(command)}")
+    print(f"[verify] input:   {input_layout} -> /input/design.gds", flush=True)
+
+    container = client.containers.create(
+        image,
+        command=command,
+        working_dir="/workspace",
+        network_disabled=True,
+        mem_limit=mem_limit,
+        environment={
+            "COLUMNS": "200",
+            "TERM": "xterm-256color",
+        },
+    )
+
+    try:
+        # Upload the layout to /input/design.gds and create an empty /output,
+        # both via put_archive("/", ...) — no bind mounts, just like production.
+        container.put_archive("/", create_tar_archive(input_layout, "input/design.gds"))
+        container.put_archive("/", create_directory_tar("output"))
+
+        print("[verify] starting container…", flush=True)
+        container.start()
+
+        # Stream the precheck log live so CI shows progress and failures.
+        for chunk in container.logs(stream=True, follow=True):
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.flush()
+
+        exit_code = container.wait()["StatusCode"]
+        print(f"\n[verify] container exited with status {exit_code}")
+
+        output_ok = _output_gds_present(container)
+        if exit_code == 0 and output_ok:
+            print("[verify] PASS: precheck completed and /output/design.gds was written")
+            return 0
+
+        if exit_code == 0 and not output_ok:
+            print("[verify] FAIL: precheck exited 0 but no /output/design.gds was produced")
+            return 1
+
+        print("[verify] FAIL: precheck reported a failure (non-zero exit)")
+        return exit_code
+    finally:
+        container.remove(force=True)
+
+
+def _output_gds_present(container) -> bool:
+    """Return True if /output/design.gds exists in the container and is non-empty."""
+    try:
+        _bits, stat = container.get_archive("/output/design.gds")
+    except docker.errors.NotFound:
+        return False
+    size = stat.get("size", 0)
+    print(f"[verify] /output/design.gds size: {size} bytes")
+    return size > 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--image",
+        required=True,
+        help="Image to verify, ideally the immutable image ID (sha256:...) so a "
+        "concurrent build cannot move the tag out from under the test.",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path on the host to the layout to check (uploaded as /input/design.gds).",
+    )
+    parser.add_argument("--top", required=True, help="Top-level cell name.")
+    parser.add_argument(
+        "--slot",
+        required=True,
+        choices=["1x1", "0p5x1", "1x0p5", "0p5x0p5"],
+        help="Slot size of the design.",
+    )
+    parser.add_argument(
+        "--id",
+        default="DEADBEEF",
+        help="8-character die ID passed to the precheck (default: DEADBEEF).",
+    )
+    parser.add_argument(
+        "--mem-limit",
+        default="24g",
+        help="Container memory limit, matching the platform (default: 24g).",
+    )
+    args = parser.parse_args()
+
+    if not args.input.is_file():
+        parser.error(f"input layout does not exist: {args.input}")
+
+    return run_check(
+        image=args.image,
+        input_layout=args.input,
+        top=args.top,
+        slot=args.slot,
+        die_id=args.id,
+        mem_limit=args.mem_limit,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_precheck_docker.py
+++ b/scripts/verify_precheck_docker.py
@@ -35,10 +35,12 @@ Exit status is ``0`` only if the container exits ``0`` *and* a non-empty
 
 import argparse
 import io
+import shutil
 import sys
 import tarfile
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 import docker
 import docker.errors
@@ -77,10 +79,13 @@ def run_check(
     slot: str,
     die_id: str,
     mem_limit: str,
+    output_path: Optional[Path] = None,
 ) -> int:
     """Run the precheck in a container exactly as the platform does.
 
-    Returns the container exit code (and asserts the output GDS exists).
+    Returns the container exit code (and asserts the output GDS exists). If
+    ``output_path`` is given, the produced ``/output/design.gds`` is copied
+    there so callers (e.g. CI) can upload it as an artifact.
     """
     client = docker.from_env()
 
@@ -134,7 +139,7 @@ def run_check(
         exit_code = container.wait()["StatusCode"]
         print(f"\n[verify] container exited with status {exit_code}")
 
-        output_ok = _output_gds_present(container)
+        output_ok = fetch_output_gds(container, output_path) > 0
         if exit_code == 0 and output_ok:
             print("[verify] PASS: precheck completed and /output/design.gds was written")
             return 0
@@ -149,15 +154,34 @@ def run_check(
         container.remove(force=True)
 
 
-def _output_gds_present(container) -> bool:
-    """Return True if /output/design.gds exists in the container and is non-empty."""
+def fetch_output_gds(container, dest: Optional[Path]) -> int:
+    """Return the size of /output/design.gds, copying it to ``dest`` if given.
+
+    Returns 0 (and copies nothing) if the file does not exist in the container.
+    """
     try:
-        _bits, stat = container.get_archive("/output/design.gds")
+        bits, stat = container.get_archive("/output/design.gds")
     except docker.errors.NotFound:
-        return False
+        print("[verify] /output/design.gds not found in container")
+        return 0
+
     size = stat.get("size", 0)
     print(f"[verify] /output/design.gds size: {size} bytes")
-    return size > 0
+
+    if dest is not None and size > 0:
+        # get_archive yields a tar stream; pull the single design.gds member out.
+        buf = io.BytesIO()
+        for chunk in bits:
+            buf.write(chunk)
+        buf.seek(0)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(fileobj=buf, mode="r") as tar:
+            extracted = tar.extractfile(tar.getmember("design.gds"))
+            with open(dest, "wb") as out:
+                shutil.copyfileobj(extracted, out)
+        print(f"[verify] copied output GDS to {dest} ({dest.stat().st_size} bytes)")
+
+    return size
 
 
 def main() -> int:
@@ -191,6 +215,13 @@ def main() -> int:
         default="24g",
         help="Container memory limit, matching the platform (default: 24g).",
     )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="If set, copy the produced /output/design.gds to this host path "
+        "(e.g. for uploading as a CI artifact).",
+    )
     args = parser.parse_args()
 
     if not args.input.is_file():
@@ -203,6 +234,7 @@ def main() -> int:
         slot=args.slot,
         die_id=args.id,
         mem_limit=args.mem_limit,
+        output_path=args.output,
     )
 
 


### PR DESCRIPTION
## What & why

The `docker-publish` workflow built and pushed the precheck image but never proved the resulting image could actually run a check. This PR makes a **complete DRC run gate publishing**, so a broken image can never reach `:latest` — which is exactly the tag the platform pulls (`PRECHECK_DOCKER_IMAGE = "ghcr.io/wafer-space/gf180mcu-precheck:latest"`).

The verification reproduces the **exact** way the checker machines launch a check (read from `platform.wafer.space` `wafer_space/projects/tasks_checks.py:do_starting`), not a convenient shortcut.

## How it works

`docker-publish.yml` is restructured into **build → verify → push**:

1. **Build** with `load: true` (`provenance: false` so it imports into the daemon); the immutable image ID is captured as `steps.build.outputs.imageid`.
2. **Verify** — `scripts/verify_precheck_docker.py` runs a complete DRC check against that image, mirroring the platform exactly:
   - command line: `python3 precheck.py --input /input/design.gds --output /output/design.gds --top … --slot … --id …`
   - container config: `working_dir=/workspace`, `network_disabled=True`, `mem_limit=24g`, `COLUMNS=200`/`TERM=xterm-256color`
   - no bind mounts: the layout is uploaded via `put_archive` to `/input/design.gds` and an empty `/output` is created, then the output GDS is read back
   - asserts container exit `0` **and** a non-empty `/output/design.gds`
   - the image is pinned by its **immutable ID, never a tag**, so a concurrent build can't swap it out from under the test
3. **Push** (existing non-PR / main-repo gate) — `scripts/push_image_tags.py` re-tags the **exact verified image ID** onto each registry tag and pushes it. No rebuild → the registry receives byte-for-byte the image that passed verification.

Verification also runs on PRs (build + verify, no push), giving pre-merge coverage of the published artifact.

## Notes

- **Test design:** `5v / 0p5x0p5` (smallest, from `gf180mcu-example-layouts`), fed straight to `/input/design.gds` exactly as the platform copies user bytes (KLayout content-detects the format). Expanding to a slot×domain matrix is a one-line change.
- **No `--cob`:** matches the real checker command; `generate_id.py` with `cob=False` skips the CoB-only assertions, so the example designs pass.
- Both helper scripts declare their deps inline (PEP 723) and run via `uv run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)