### PR TITLE
[MAKEFILE] Add md5 and compression to the precheck recipes + import envvars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@ PDK_ROOT ?= $(MAKEFILE_DIR)/gf180mcu
 PDK ?= gf180mcuD
 PDK_COMMIT ?= d658698bd8bcf4e05fc7b5991a701247ba0d744c
 
-MANIFACTURING_ID ?= DEADBEEF 
+ID ?= DEADBEEF 
 THREADS ?= 1
+WORKERS ?= max
 INPUT ?= gf180mcu-example-layouts/${DOMAIN}/${SLOT}/${TOP}.oas  
  
 .DEFAULT_GOAL := help
@@ -38,19 +39,10 @@ clone-layouts: gf180mcu-example-layouts
 .PHONY: clone-layouts
 
 precheck: clone-pdk clone-layouts
-	python3 precheck.py --slot ${SLOT} --cob --input ${INPUT} --id ${MANIFACTURER_ID} --workers max --threads ${THREADS} --output ${TOP}.oas
-	md5sum ${INPUT} | awk '{print $$1}' > $(TOP).mds
-	gzip -kf ${TOP}.oas
+	python3 precheck.py --slot ${SLOT} --cob --input ${INPUT} --id ${ID} --workers ${WORKERS} --threads ${THREADS} --output ${TOP}.oas
 .PHONY: precheck
 
 precheck-no-cob: clone-pdk clone-layouts
-	python3 precheck.py --slot ${SLOT} --input ${INPUT} --id ${MANIFACTURER_ID} --workers max --threads ${THREADS} --output ${TOP}.oas
-	md5sum ${INPUT} | awk '{print $$1}' > $(TOP).mds
-	gzip -kf ${TOP}.oas	
+	python3 precheck.py --slot ${SLOT} --input ${INPUT} --id ${ID} --workers ${WORKERS} --threads ${THREADS} --output ${TOP}.oas
 .PHONY: precheck-no-cob
 
-clean: ## Delete *.oas, *.md5 and *.gz 
-	rm -f ./*.oas
-	rm -f ./*.md5
-	rm -f ./*.gz
-.PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ precheck-no-cob: clone-pdk clone-layouts
 	gzip -kf ${TOP}.oas	
 .PHONY: precheck-no-cob
 
-clean: 
+clean: ## Delete *.oas, *.md5 and *.gz 
 	rm -f ./*.oas
 	rm -f ./*.md5
 	rm -f ./*.gz

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFILE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 RUN_TAG = $(shell ls librelane/runs/ | tail -n 1)
-TOP = chip_top
+TOP ?= chip_top
 SLOT ?= 1x1
 DOMAIN ?= 5v
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ PDK_ROOT ?= $(MAKEFILE_DIR)/gf180mcu
 PDK ?= gf180mcuD
 PDK_COMMIT ?= d658698bd8bcf4e05fc7b5991a701247ba0d744c
 
+MANIFACTURING_ID ?= DEADBEEF 
+THREADS ?= 1
+INPUT ?= gf180mcu-example-layouts/${DOMAIN}/${SLOT}/${TOP}.oas  
+ 
 .DEFAULT_GOAL := help
 
 help: ## Show this help message
@@ -34,9 +38,19 @@ clone-layouts: gf180mcu-example-layouts
 .PHONY: clone-layouts
 
 precheck: clone-pdk clone-layouts
-	python3 precheck.py --slot ${SLOT} --cob --input gf180mcu-example-layouts/${DOMAIN}/${SLOT}/${TOP}.oas --id DEADBEEF --workers max --threads 1 --output ${TOP}.oas
+	python3 precheck.py --slot ${SLOT} --cob --input ${INPUT} --id ${MANIFACTURER_ID} --workers max --threads ${THREADS} --output ${TOP}.oas
+	md5sum ${INPUT} | awk '{print $$1}' > $(TOP).mds
+	gzip -kf ${TOP}.oas
 .PHONY: precheck
 
 precheck-no-cob: clone-pdk clone-layouts
-	python3 precheck.py --slot ${SLOT} --input gf180mcu-example-layouts/${DOMAIN}/${SLOT}/${TOP}.oas --id DEADBEEF --workers max --threads 1 --output ${TOP}.oas
+	python3 precheck.py --slot ${SLOT} --input ${INPUT} --id ${MANIFACTURER_ID} --workers max --threads ${THREADS} --output ${TOP}.oas
+	md5sum ${INPUT} | awk '{print $$1}' > $(TOP).mds
+	gzip -kf ${TOP}.oas	
 .PHONY: precheck-no-cob
+
+clean: 
+	rm -f ./*.oas
+	rm -f ./*.md5
+	rm -f ./*.gz
+.PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,3 @@ precheck: clone-pdk clone-layouts
 precheck-no-cob: clone-pdk clone-layouts
 	python3 precheck.py --slot ${SLOT} --input ${INPUT} --id ${ID} --workers ${WORKERS} --threads ${THREADS} --output ${TOP}.oas
 .PHONY: precheck-no-cob
-


### PR DESCRIPTION
Context: 
I have been running precheck locally and I am contributing back some of the features I have found the most useful from a local user's perspective.

Changes: 
- expose variables to be overrides during make invocation 
- generate `md5` of input file
- call gzip on file oas